### PR TITLE
Add PUT endpoint to replace  full player stats

### DIFF
--- a/server/docs.bruno/Mirrored_Fragments_API_Testing/Stats/Put_Endpoints/StatsReset.bru
+++ b/server/docs.bruno/Mirrored_Fragments_API_Testing/Stats/Put_Endpoints/StatsReset.bru
@@ -1,0 +1,36 @@
+meta {
+  name: StatsReset
+  type: http
+  seq: 1
+}
+
+put {
+  url: http://localhost:3000/api/stats
+  body: json
+  auth: inherit
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "emotionalStats": {
+      "confidence": 60,
+      "anxiety": 20,
+      "focus": 70,
+      "willpower": 65
+    },
+    "physicalStats": {
+      "strength": 12,
+      "stamina": 10,
+      "agility": 8
+    },
+    "mentalStats": {
+      "mentalStrength": 9,
+      "memory": 7
+    }
+  }
+  
+}

--- a/server/docs.bruno/Mirrored_Fragments_API_Testing/Stats/Put_Endpoints/folder.bru
+++ b/server/docs.bruno/Mirrored_Fragments_API_Testing/Stats/Put_Endpoints/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Put_Endpoints
+}

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -81,6 +81,29 @@ router.post('/', (req, res) => {
   });
 });
 
+// Replace all stats with a new object
+router.put('/', (req, res) => {
+  const { emotionalStats, physicalStats, mentalStats } = req.body;
+
+  if (!emotionalStats || !physicalStats || !mentalStats) {
+    return res.status(400).json({
+      success: false,
+      message: "All stat categories (emotionalStats, physicalStats, mentalStats) are required"
+    });
+  }
+
+  // Full overwrite
+  stats.emotionalStats = emotionalStats;
+  stats.physicalStats = physicalStats;
+  stats.mentalStats = mentalStats;
+
+  return res.status(200).json({
+    success: true,
+    message: "All stats replaced successfully",
+    stats
+  });
+});
+
 
 
 module.exports = router;


### PR DESCRIPTION
### **User description**
@CodiumAI-Agent /review


___

### **PR Type**
Enhancement


___

### **Description**
- Add PUT endpoint for complete player stats replacement

- Include validation for all required stat categories

- Create API testing documentation with Bruno collection


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Client Request"] --> B["PUT /api/stats"]
  B --> C["Validate Required Fields"]
  C --> D["Replace All Stats"]
  D --> E["Return Success Response"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>status.js</strong><dd><code>Add PUT endpoint for stats replacement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/routes/status.js

<li>Add PUT endpoint handler for complete stats replacement<br> <li> Implement validation for emotionalStats, physicalStats, mentalStats<br> <li> Return success response with replaced stats object


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86_S_Vignesh_Pandiyan_Capstone_Mirrored_Fragments/pull/4/files#diff-ecd584adf614cb853b149f14f32c9e2516ab2e8251d06db298f105decd72c344">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StatsReset.bru</strong><dd><code>Add Bruno test for stats reset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/docs.bruno/Mirrored_Fragments_API_Testing/Stats/Put_Endpoints/StatsReset.bru

<li>Create Bruno API test for PUT stats endpoint<br> <li> Include sample JSON payload with all stat categories<br> <li> Configure HTTP method and headers for testing


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86_S_Vignesh_Pandiyan_Capstone_Mirrored_Fragments/pull/4/files#diff-3b8a9fae747264bc1e758f04cd081bf941f3e5696cfc2b0d2868f8cf903d80fa">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>folder.bru</strong><dd><code>Add PUT endpoints folder structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/docs.bruno/Mirrored_Fragments_API_Testing/Stats/Put_Endpoints/folder.bru

- Create folder configuration for PUT endpoints collection


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86_S_Vignesh_Pandiyan_Capstone_Mirrored_Fragments/pull/4/files#diff-5ef433f0ccbb3209cd72d599dc991b1a5fec317e03ee2cbdab2d592bfa1c4919">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>